### PR TITLE
Corrige link "read on" para os artigos

### DIFF
--- a/mediumfox/templates/index.html
+++ b/mediumfox/templates/index.html
@@ -60,7 +60,7 @@
                   {% endfor %}
                   {% endif %}
                 </span>
-                <a class="full-article-link pull-right" rel="full-article" href="{{ SITEURL }}{{ article.url }}">Read on →</a>
+                <a class="full-article-link pull-right" rel="full-article" href="{{ SITEURL }}/{{ article.url }}">Read on →</a>
               </article>
             </div>
           </div>


### PR DESCRIPTION
Na página inicial o link "Read on →" está quebrado.

Esse PR ajusta a formatação do link para apontar para a página do artigo.